### PR TITLE
Change FileDialogs to native

### DIFF
--- a/Nodes/GameEntry.tscn
+++ b/Nodes/GameEntry.tscn
@@ -83,6 +83,7 @@ size = Vector2i(425, 175)
 ok_button_text = "Select Current Folder"
 file_mode = 2
 access = 2
+use_native_dialog = true
 
 [node name="AcceptDialog" type="AcceptDialog" parent="."]
 

--- a/Nodes/ModEntry.tscn
+++ b/Nodes/ModEntry.tscn
@@ -89,6 +89,7 @@ size = Vector2i(425, 175)
 ok_button_text = "Select Current Folder"
 file_mode = 2
 access = 2
+use_native_dialog = true
 
 [node name="AcceptDialog" type="AcceptDialog" parent="."]
 

--- a/Nodes/PathEdit.tscn
+++ b/Nodes/PathEdit.tscn
@@ -21,6 +21,7 @@ exclusive = false
 ok_button_text = "Select Current Folder"
 file_mode = 2
 access = 2
+use_native_dialog = true
 
 [connection signal="text_changed" from="LineEdit" to="." method="line_edit_text_changed" unbinds=1]
 [connection signal="pressed" from="Button" to="." method="browse"]


### PR DESCRIPTION
Changes the FileDialogs used to open files and such into native ones. This makes the program a lot easier to use for end users or even modders who may not be familiar with Godot's file manager. It also lets people use the file manager they know with all of their settings. Can't see a pro for keeping the Godot one.